### PR TITLE
Fixes a small typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A: Well, you can use it with docker compose if you don't want the GPU support. T
 To get the logs of the running container
 
 ```sh
-d ocker logs -f fahclient
+docker logs -f fahclient
 ```
 
 ## Build


### PR DESCRIPTION
This fixes a small typo in the README.md file:

`d ocker logs...` -> `docker logs...`

Signed-off-by: Chris Collins <collins.christopher@gmail.com>